### PR TITLE
fix package name in installation instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Yii 2 class for working with Imagick.
 Run the following command
 
 ```bash
-$ composer require tpmanc/imagick "*"
+$ composer require tpmanc/yii2-imagick "*"
 ```
 
 or add
 
 ```bash
-$ "tpmanc/imagick": "*"
+$ "tpmanc/yii2-imagick": "*"
 ```
 
 to the require section of your `composer.json` file.


### PR DESCRIPTION
Changed package name from "tpmanc/imagick" to "tpmanc/yii2-imagick" in installation instructions in readme
